### PR TITLE
Model evaluator

### DIFF
--- a/mithridatium/defenses/mmbd.py
+++ b/mithridatium/defenses/mmbd.py
@@ -1,0 +1,148 @@
+from __future__ import absolute_import
+from __future__ import print_function
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torchvision.models import resnet18
+
+from mithridatium.report import write_report
+
+import argparse
+import random
+import numpy as np
+
+#Code adapted from https://github.com/wanghangpsu/MM-BD/blob/main/univ_bd.py
+
+def get_device(device_index=0):
+    if torch.cuda.is_available():
+        return torch.device(f"cuda:{device_index}")
+    elif hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+        return torch.device("mps")
+    else:
+        return torch.device("cpu")
+
+parser = argparse.ArgumentParser(description='UnivBD method')
+parser.add_argument('--model_dir', default='model1', help='model path')
+parser.add_argument('--device', default=0, type=int)
+parser.add_argument("--report_out", default="reports/mmbd_report.json", help="JSON output path")
+#parser.add_argument('--data_path', '-d', required=True, help='data path')
+args = parser.parse_args()
+
+def load_resnet18_cifar10(weights_path, device=0):
+    model = resnet18(weights=None)
+    model.fc = nn.Linear(model.fc.in_features, 10)
+
+    try:
+        state = torch.load(weights_path, map_location=device, weights_only=True)
+    except TypeError:
+        state = torch.load(weights_path, map_location=device)
+
+    model.load_state_dict(state, strict=True)
+    model.to(device).eval()
+    return model
+
+random.seed()
+device = get_device(args.device)
+
+# Detection parameters
+NC = 10
+NI = 150
+PI = 0.9
+NSTEP = 300
+TC = 6
+batch_size = 20
+
+# Load model
+model = load_resnet18_cifar10(args.model_dir, device)
+criterion = nn.CrossEntropyLoss()
+
+model.eval()
+
+def lr_scheduler(iter_idx):
+    lr = 1e-2
+
+
+    return lr
+
+res = []
+for t in range(10):
+
+    images = torch.rand([30, 3, 32, 32]).to(device)
+    images.requires_grad = True
+
+    last_loss = 1000
+    labels = t * torch.ones((len(images),), dtype=torch.long).to(device)
+    onehot_label = F.one_hot(labels, num_classes=NC)
+    for iter_idx in range(NSTEP):
+
+        optimizer = torch.optim.SGD([images], lr=lr_scheduler(iter_idx), momentum=0.2)
+        optimizer.zero_grad()
+        outputs = model(torch.clamp(images, min=0, max=1))
+
+        loss = -1 * torch.sum((outputs * onehot_label)) \
+               + torch.sum(torch.max((1-onehot_label) * outputs - 1000 * onehot_label, dim=1)[0])
+        loss.backward(retain_graph=True)
+        optimizer.step()
+        if abs(last_loss - loss.item())/abs(last_loss)< 1e-5:
+            break
+        last_loss = loss.item()
+
+    res.append(torch.max(torch.sum((outputs * onehot_label), dim=1)\
+               - torch.max((1-onehot_label) * outputs - 1000 * onehot_label, dim=1)[0]).item())
+
+stats = np.array(res, dtype=float)
+from scipy.stats import median_abs_deviation as MAD
+from scipy.stats import gamma
+mad = MAD(stats, scale='normal')
+mad = float(mad) if mad != 0 else 1e-12
+abs_deviation = np.abs(stats - np.median(stats))
+score = abs_deviation / mad
+
+
+np.save('results.npy', np.array(res))
+ind_max = np.argmax(stats)
+r_eval = np.amax(stats)
+r_null = np.delete(stats, ind_max)
+
+shape, loc, scale = gamma.fit(r_null)
+pv = 1 - pow(gamma.cdf(r_eval, a=shape, loc=loc, scale=scale), len(r_null)+1)
+verdict = "no_attack" if pv > 0.05 else "attack"
+
+thresholds = {
+    "p_value": 0.05,
+    "normalized_score": {
+        "normal": [0.0, 1.5],
+        "mild": [1.5, 3.0],
+        "suspicious": [3.0, 5.0],
+        "very_suspicious": [5.0, None]
+    },
+}
+
+parameters = {
+    "NC": NC,
+    "NSTEP": NSTEP,
+    "optimizer": "SGD(momentum=0.2)",
+    "lr_init": 1e-2,
+    "device": str(device),
+}
+
+results = {
+    "defense": "MMBD",
+    "model_path": args.model_dir,
+    "per_class_scores": stats.tolist(),
+    "normalized_scores": score.tolist(),
+    "p_value": float(pv),
+    "verdict": verdict,
+    "suspected_target": (ind_max if verdict == "attack" else None),
+    "thresholds": thresholds,
+    "parameters": parameters
+}
+
+write_report(
+    model_path=args.model_dir,
+    defense="MMBD",
+    out_path=args.report_out,
+    details=results,
+    version="0.1.0"
+)

--- a/mithridatium/evaluator.py
+++ b/mithridatium/evaluator.py
@@ -1,33 +1,68 @@
 # mithridatium/evaluator.py
 import torch
+import torch.nn as nn
+from typing import Tuple
 
-@torch.no_grad()
-def extract_embeddings(model, dataloader, feature_module):
+def extract_embeddings(model: nn.Module, loader: torch.utils.data.DataLoader, feature_module: nn.Module) -> Tuple[torch.Tensor, torch.Tensor]:
     """
-    Collect penultimate features using a forward hook on `feature_module`
-    (e.g., resnet.avgpool). Returns:
-      embs:  [N, D] tensor
-      labels:[N] tensor
+    Extract penultimate-layer embeddings and labels from a model and dataloader.
+    Args:
+        model: The neural network model (e.g., resnet18).
+        loader: DataLoader for the dataset.
+        feature_module: The module in the model whose output is the embedding (e.g., model.avgpool or model.layer4).
+    Returns:
+        embs: Tensor of shape [N, D] (embeddings)
+        labels: Tensor of shape [N] (labels)
     """
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    model.to(device).eval()
+    model.eval()
+    embs = []
+    labels = []
+    device = next(model.parameters()).device
 
-    feats_list, labels_list = [], []
+    def hook_fn(module, input, output):
+        hook_fn.embeddings = output.detach()
+    hook_fn.embeddings = None
+    hook = feature_module.register_forward_hook(hook_fn)
 
-    def hook(_m, _inp, out):
-        # avgpool output is [B, C, 1, 1]; flatten to [B, C]
-        feats_list.append(out.detach().flatten(1).cpu())
-
-    # Register the hook on the target layer
-    handle = feature_module.register_forward_hook(lambda m, i, o: hook(m, i, o))
-    try:
-        for x, y in dataloader:
+    with torch.no_grad():
+        for x, y in loader:
             x = x.to(device)
-            _ = model(x)   # running forward triggers the hook
-            labels_list.append(y) # keep labels to align with the embeddings
-    finally:
-        handle.remove()
-
-    embs = torch.cat(feats_list, dim=0)
-    labels = torch.cat(labels_list, dim=0)
+            _ = model(x)
+            emb = hook_fn.embeddings
+            if emb.dim() > 2:
+                emb = torch.flatten(emb, start_dim=1)
+            embs.append(emb.cpu())
+            labels.append(y.cpu())
+    hook.remove()
+    embs = torch.cat(embs, dim=0)
+    labels = torch.cat(labels, dim=0)
     return embs, labels
+
+def evaluate(model: nn.Module, loader: torch.utils.data.DataLoader) -> Tuple[float, float]:
+    """
+    Evaluate model on a dataset.
+    Args:
+        model: The neural network model.
+        loader: DataLoader for the dataset.
+    Returns:
+        loss: Average loss (float)
+        accy: Accuracy (float)
+    """
+    model.eval()
+    criterion = nn.CrossEntropyLoss()
+    total_loss = 0.0
+    correct = 0
+    total = 0
+    device = next(model.parameters()).device
+    with torch.no_grad():
+        for x, y in loader:
+            x, y = x.to(device), y.to(device)
+            out = model(x)
+            loss = criterion(out, y)
+            total_loss += loss.item() * y.size(0)
+            pred = out.argmax(1)
+            correct += (pred == y).sum().item()
+            total += y.size(0)
+    avg_loss = total_loss / total
+    accy = correct / total
+    return avg_loss, accy

--- a/mithridatium/loader.py
+++ b/mithridatium/loader.py
@@ -1,4 +1,9 @@
-# mithridatium/loader.py
+from torchvision.models import resnet18
+import mithridatium.loader as loader
+
+model = resnet18(weights=None)
+feature_module = loader.get_feature_module(model)
+print(feature_module)  # Should print: <class 'torch.nn.modules.pooling.AdaptiveAvgPool2d'># mithridatium/loader.py
 from pathlib import Path
 import torch
 import torch.nn as nn
@@ -21,3 +26,14 @@ def load_resnet18(model_path: str | None):
 
     model.eval()
     return model, feature_module
+
+def get_feature_module(model):
+    """
+    Returns the penultimate feature module for a given model architecture.
+    For ResNet-18, returns model.avgpool.
+    """
+    arch = model.__class__.__name__
+    if arch == 'ResNet':
+        return model.avgpool
+    else:
+        raise NotImplementedError(f"Feature module not defined for architecture: {arch}")

--- a/mithridatium/loader.py
+++ b/mithridatium/loader.py
@@ -1,9 +1,3 @@
-from torchvision.models import resnet18
-import mithridatium.loader as loader
-
-model = resnet18(weights=None)
-feature_module = loader.get_feature_module(model)
-print(feature_module)  # Should print: <class 'torch.nn.modules.pooling.AdaptiveAvgPool2d'># mithridatium/loader.py
 from pathlib import Path
 import torch
 import torch.nn as nn
@@ -31,9 +25,13 @@ def get_feature_module(model):
     """
     Returns the penultimate feature module for a given model architecture.
     For ResNet-18, returns model.avgpool.
+    Extend this function for other architectures as needed.
     """
     arch = model.__class__.__name__
     if arch == 'ResNet':
         return model.avgpool
+    # Example for future extension:
+    # elif arch == 'VGG':
+    #     return model.classifier[0]
     else:
         raise NotImplementedError(f"Feature module not defined for architecture: {arch}")

--- a/mithridatium/report.py
+++ b/mithridatium/report.py
@@ -11,6 +11,28 @@ import json
 import datetime as dt
 from pathlib import Path
 
+def write_report(model_path: str, defense: str, out_path: str, details, version: str = "0.1.0"):
+    payload = {
+        "mithridatium_version": version,
+        "timestamp_utc": dt.datetime.utcnow().isoformat() + "Z",
+        "model_path": str(model_path),
+        "defense": defense,
+        "status": "ok" if details else "empty"
+    }
+
+    if details is not None:
+        payload["details"] = _json_safe(details)
+
+
+    out_file = Path(out_path)
+    out_file.parent.mkdir(parents=True, exist_ok=True)
+
+    with out_file.open("w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2, ensure_ascii=False, sort_keys=True)
+
+    print(f"[ok] Report written to {out_file.resolve()}")
+    return payload
+
 def write_dummy_report(model_path: str, defense: str, out_path: str, version: str = "0.1.0"):
     """
     Write a placeholder JSON report. Used for Sprint 1 demo.
@@ -37,3 +59,17 @@ def write_dummy_report(model_path: str, defense: str, out_path: str, version: st
 
     print(f"[ok] Dummy report written to {out_file.resolve()}")
     return payload
+
+def _json_safe(obj):
+    import numpy as np
+    if isinstance(obj, dict):
+        return {k: _json_safe(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [_json_safe(v) for v in obj]
+    if isinstance(obj, np.ndarray):
+        return obj.tolist()
+    if isinstance(obj, (np.floating,)):
+        return float(obj)
+    if isinstance(obj, (np.integer,)):
+        return int(obj)
+    return obj

--- a/scripts/check_evaluator.py
+++ b/scripts/check_evaluator.py
@@ -1,14 +1,31 @@
-# scripts/check_evaluator.py
-from mithridatium.loader import load_resnet18
-from mithridatium.data import get_cifar10_loader
-from mithridatium.evaluator import extract_embeddings
+import torch
+from torchvision import datasets, transforms
+from torch.utils.data import DataLoader
+from torchvision.models import resnet18
+import mithridatium.evaluator as evaluator
+import mithridatium.loader as loader
 
 def main():
-    model, feat = load_resnet18("models/resnet18.pth")  # fine if missing
-    loader = get_cifar10_loader(batch_size=64)          # downloads CIFAR-10 once
-    embs, labels = extract_embeddings(model, loader, feat)
-    print("Embeddings shape:", embs.shape)  # expect ~ [10000, 512] for ResNet-18
-    print("Labels shape:", labels.shape)    # expect [10000]
+    # Load a pretrained or random resnet18
+    model = resnet18(weights=None)
+    model.fc = torch.nn.Linear(model.fc.in_features, 10)
+    model.eval()
+
+    # Prepare CIFAR10 test set
+    transform = transforms.Compose([
+        transforms.ToTensor(),
+        transforms.Normalize((0.4914, 0.4822, 0.4465), (0.2023, 0.1994, 0.2010))
+    ])
+    testset = datasets.CIFAR10('./data', train=False, download=True, transform=transform)
+    test_loader = DataLoader(testset, batch_size=256, shuffle=False)
+
+    feature_module = loader.get_feature_module(model)
+
+    embs, labels = evaluator.extract_embeddings(model, test_loader, feature_module)
+    print(f"Embeddings shape: {embs.shape}")
+
+    loss, accy = evaluator.evaluate(model, test_loader)
+    print(f"Test accuracy: {accy*100:.2f}% | Test loss: {loss:.4f}")
 
 if __name__ == "__main__":
     main()

--- a/scripts/check_evaluator.py
+++ b/scripts/check_evaluator.py
@@ -1,3 +1,4 @@
+import argparse
 import torch
 from torchvision import datasets, transforms
 from torch.utils.data import DataLoader
@@ -6,24 +7,30 @@ import mithridatium.evaluator as evaluator
 import mithridatium.loader as loader
 
 def main():
-    # Load a pretrained or random resnet18
-    model = resnet18(weights=None)
-    model.fc = torch.nn.Linear(model.fc.in_features, 10)
-    model.eval()
+    parser = argparse.ArgumentParser()
+    '''
+    .venv/bin/python -m scripts.check_evaluator --model models/resnet18_poison.pth
+    '''
+    parser.add_argument("--model", type=str, default="models/resnet18_bd.pth", help="Path to model checkpoint")
+    parser.add_argument("--batch_size", type=int, default=256, help="Batch size for evaluation")
+    args = parser.parse_args()
 
-    # Prepare CIFAR10 test set
+    # Load model from checkpoint
+    model, feature_module = loader.load_resnet18(args.model)
+
+    # Prepare CIFAR-10 test set
     transform = transforms.Compose([
         transforms.ToTensor(),
         transforms.Normalize((0.4914, 0.4822, 0.4465), (0.2023, 0.1994, 0.2010))
     ])
     testset = datasets.CIFAR10('./data', train=False, download=True, transform=transform)
-    test_loader = DataLoader(testset, batch_size=256, shuffle=False)
+    test_loader = DataLoader(testset, batch_size=args.batch_size, shuffle=False)
 
-    feature_module = loader.get_feature_module(model)
-
+    # Extract embeddings
     embs, labels = evaluator.extract_embeddings(model, test_loader, feature_module)
     print(f"Embeddings shape: {embs.shape}")
 
+    # Evaluate accuracy
     loss, accy = evaluator.evaluate(model, test_loader)
     print(f"Test accuracy: {accy*100:.2f}% | Test loss: {loss:.4f}")
 

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -1,0 +1,39 @@
+import torch
+from torchvision import datasets, transforms
+from torch.utils.data import DataLoader
+from torchvision.models import resnet18
+import mithridatium.evaluator as evaluator
+import mithridatium.loader as loader
+import unittest
+
+class TestEvaluator(unittest.TestCase):
+    def test_extract_embeddings_and_evaluate(self):
+        # Use a small subset of CIFAR10
+        transform = transforms.Compose([
+            transforms.ToTensor(),
+            transforms.Normalize((0.4914, 0.4822, 0.4465), (0.2023, 0.1994, 0.2010))
+        ])
+        testset = datasets.CIFAR10('./data', train=False, download=True, transform=transform)
+        indices = list(range(512))
+        subset = torch.utils.data.Subset(testset, indices)
+        loader_ = DataLoader(subset, batch_size=128, shuffle=False)
+
+        model = resnet18(weights=None)
+        model.fc = torch.nn.Linear(model.fc.in_features, 10)
+        model.eval()
+
+        feature_module = loader.get_feature_module(model)
+        embs, labels = evaluator.extract_embeddings(model, loader_, feature_module)
+        print(f"Embeddings shape: {embs.shape}")
+        print(f"Labels shape: {labels.shape}")
+        print(f"First 5 labels: {labels[:5].tolist()}")
+        loss, accy = evaluator.evaluate(model, loader_)
+        print(f"Loss: {loss:.4f}")
+        print(f"Accuracy: {accy*100:.2f}%")
+        self.assertTrue(embs.shape[0] > 0)
+        self.assertTrue(labels.shape[0] > 0)
+        self.assertTrue(loss >= 0)
+        self.assertTrue(accy >= 0)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Original issue (evaluator and penultimate layer extraction): https://github.com/orgs/oss-slu/projects/52/views/1?pane=issue&itemId=130143762&issue=oss-slu%7Cmithridatium%7C11

Acceptance Criteria

mithridatium.evaluator.extract_embeddings(model, loader, feature_module) returns tensors (embs:[N,D], labels:[N]).

mithridatium.evaluator.evaluate(model, loader) returns {"loss": float, "acc": float}.

Works for both clean and backdoored ResNet-18.

Unit test: tiny subset (e.g., 512 samples) runs end-to-end and returns shapes > 0.


This pull request includes Will's work in implementing MMBD, and  introduces evluation methods and scripts, new tests and updates the evaluator checking script. The main themes are: new defense method, evaluation/reporting improvements, code refactoring for model/feature handling, and enhanced testing.

**Evaluation  Improvements:**
* Refactored `extract_embeddings` in `mithridatium/evaluator.py` for clarity, type safety, and device compatibility; added a new `evaluate` function for model accuracy and loss computation.

**Model and Feature Extraction Refactoring:**
* Added `get_feature_module` to `mithridatium/loader.py` to generalize extraction of penultimate feature modules for different architectures, improving extensibility.
* Minor cleanup in `mithridatium/loader.py` by removing redundant file header comment.

**Testing and Script Updates:**
* Added `tests/test_evaluator.py` with a unit test for embedding extraction and evaluation, supporting environment-based configuration and subset testing for reproducibility.
* Updated `scripts/check_evaluator.py` to use the new loader and evaluator APIs, support command-line arguments, and print model accuracy and embedding shapes.

Before pushing, I decided to add a --model argument to my scripts so you can specify which model checkpoint you want to load. 