### PR TITLE
Issue 18

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,8 @@ dist/
 # Data & models
 data/
 models/
-reports/*.json
+/reports/*
+!/reports/report_schema.json
 
 # Notebooks & logs
 *.ipynb_checkpoints/

--- a/mithridatium/cli.py
+++ b/mithridatium/cli.py
@@ -9,6 +9,7 @@ VERSION = "0.1.0"
 DEFENSES = {"spectral", "mmbd"}
 
 EXIT_USAGE_ERROR = 64     # invalid CLI usage (e.g., unsupported --defense)
+EXIT_DATA_ERR = 65  # invalid data format (schema failures)
 EXIT_NO_INPUT = 66        # input file missing/not a file
 EXIT_CANT_CREATE = 73     # cannot create/overwrite output without --force
 EXIT_IO_ERROR = 74        # input exists but can't be opened/read
@@ -41,25 +42,6 @@ def _write_json(obj: dict, out_path: str, force: bool) -> None:
 
     with path.open("w", encoding="utf-8") as f:
         json.dump(obj, f, indent=2)
-
-
-def dummy_report(model_path: str, defense: str, out_path: str, force: bool) -> None:
-    """
-    Nothing runs yet, just a dummy report.
-    """
-    
-    # dummy report:
-    report = {
-        "mithridatium_version": VERSION,
-        "model_path": model_path,
-        "defense": defense,
-        "status": "Not yet implemented", 
-    }
-
-    _write_json(report, out_path, force)
-    where = "stdout" if out_path == "-" else out_path
-    typer.echo(f"Report written to {where}")
-
 
 @app.callback(invoke_without_command=True)
 def _root(
@@ -169,8 +151,64 @@ def detect(
     rep = rpt.build_report(model_path=str(p), defense=d, dataset=data, version=VERSION, results=results)
 
     _write_json(rep, out, force)
-    print(rpt.render_summary(rep))
 
+@app.command("show-report")
+def show_report(
+    file: str = typer.Option(..., "--file", "-f", help="Path to a JSON report file."),
+    mode: str = typer.Option(
+        "json",
+        "--mode",
+        "-m",
+        help="Display report as 'json' (pretty JSON) or 'summary' (human-readable).",
+    ),
+    schema: str = typer.Option(
+        None,
+        "--schema",
+        help="Optional schema path; defaults to bundled schema.",
+    ),
+) -> None:
+    """
+    Pretty-print a saved report. Validates first:
+    - If valid: prints chosen view (no extra messages).
+    - If invalid: prints a single error and exits non-zero.
+    """
+    p = Path(file)
+    if not p.exists() or not p.is_file():
+        typer.secho(f"Error: report file not found: {p}", err=True)
+        raise typer.Exit(code=EXIT_NO_INPUT)
 
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+    except Exception as ex:
+        typer.secho(f"Error: failed to read/parse JSON: {p}\nReason: {ex}", err=True)
+        raise typer.Exit(code=EXIT_IO_ERROR)
+
+    # Validate (silent on success)
+    try:
+        rpt.validate_report_data(data, schema=schema)
+    except RuntimeError as ex:
+        # jsonschema missing or similar setup issue
+        typer.secho(f"Error: {ex}", err=True)
+        raise typer.Exit(code=EXIT_USAGE_ERROR)
+    except Exception as ex:
+        typer.secho("Report not valid.", err=True)
+        typer.secho(f"Reason: {ex}", err=True)
+        raise typer.Exit(code=EXIT_DATA_ERR)
+
+    # If we reach here, it's valid—print the chosen view
+    if mode.lower() == "json":
+        typer.echo(json.dumps(data, indent=2, ensure_ascii=False, sort_keys=True))
+    elif mode.lower() == "summary":
+        try:
+            summary = rpt.render_summary(data)
+            typer.echo(summary)
+        except Exception as ex:
+            typer.secho("Error: could not render summary. Is this a valid report JSON?", err=True)
+            typer.secho(f"Reason: {ex}", err=True)
+            raise typer.Exit(code=EXIT_DATA_ERR)
+    else:
+        typer.secho("Error: --mode must be 'json' or 'summary'", err=True)
+        raise typer.Exit(code=EXIT_USAGE_ERROR)
+    
 if __name__ == "__main__":
     app()

--- a/mithridatium/cli_notes.md
+++ b/mithridatium/cli_notes.md
@@ -79,6 +79,21 @@ cd mithridatium
 mithridatium detect -m ../models/resnet18_clean.pth -D spectral -d cifar10 -o ../reports/spectral.json
 ```
 
+### Show a saved report (validate then display)
+
+`show-report` first **validates** the JSON against the schema at `reports/report_schema.json`.
+
+- If valid: prints the chosen view (default **pretty JSON**).
+- If invalid: prints a single error and exits non-zero.
+
+```bash
+# Pretty JSON (default)
+mithridatium show-report -f reports/spectral.json
+
+# Human-readable summary (if you kept render_summary)
+mithridatium show-report -f reports/spectral.json --mode summary
+```
+
 ---
 
 ## Output
@@ -105,6 +120,7 @@ mithridatium detect -m ../models/resnet18_clean.pth -D spectral -d cifar10 -o ..
 ## Exit codes
 
 - `64` (`EXIT_USAGE_ERROR`) – invalid CLI usage (e.g., unsupported `--defense`).
+- `65` (`EXIT_DATA_ERR`) – invalid report data (schema validation failed in `show-report`).
 - `66` (`EXIT_NO_INPUT`) – model path missing or not a file.
 - `73` (`EXIT_CANT_CREATE`) – output file exists and `--force` not supplied.
 - `74` (`EXIT_IO_ERROR`) – I/O problems (e.g., `torch.load` failed, unreadable file).

--- a/mithridatium/report.py
+++ b/mithridatium/report.py
@@ -5,6 +5,32 @@ import datetime as dt
 from pathlib import Path
 from typing import Dict, Any
 import torch
+import jsonschema
+
+def build_report(model_path: str, defense: str, dataset: str, version: str = "0.1.0",
+                 results: Dict[str, Any] | None = None) -> Dict[str, Any]:
+    return {
+        "mithridatium_version": version,
+        "model_path": model_path,
+        "defense": defense,
+        "dataset": dataset,
+        "results": results or {
+            "suspected_backdoor": False,
+            "num_flagged": 0,
+            "top_eigenvalue": 0.0,
+        },
+    }
+
+def render_summary(report: Dict[str, Any]) -> str:
+    r = report["results"]
+    return (
+        f"Mithridatium {report['mithridatium_version']} | "
+        f"defense={report['defense']} | dataset={report['dataset']}\n"
+        f"- model_path:        {report['model_path']}\n"
+        f"- suspected_backdoor:{r.get('suspected_backdoor')}\n"
+        f"- num_flagged:       {r.get('num_flagged')}\n"
+        f"- top_eigenvalue:    {r.get('top_eigenvalue')}"
+    )
 
 def run_spectral(model_path: str, dataset: str, iters: int = 50) -> dict:
     """
@@ -31,85 +57,10 @@ def run_spectral(model_path: str, dataset: str, iters: int = 50) -> dict:
 
     return {"suspected_backdoor": bool(suspected), "num_flagged": 0, "top_eigenvalue": top_ev}
 
-
-# def write_dummy_report(model_path: str, defense: str, out_path: str, version: str = "0.1.0",results: Dict[str, Any] | None = None) -> Dict[str, Any]:
-def write_report(model_path: str, defense: str, out_path: str, details, version: str = "0.1.0"):
-    payload = {
-        "mithridatium_version": version,
-        "timestamp_utc": dt.datetime.utcnow().isoformat() + "Z",
-        "model_path": str(model_path),
-        "defense": defense,
-        "status": "ok" if details else "empty"
-    }
-
-    if details is not None:
-        payload["details"] = _json_safe(details)
-
-
-    out_file = Path(out_path)
-    out_file.parent.mkdir(parents=True, exist_ok=True)
-
-    with out_file.open("w", encoding="utf-8") as f:
-        json.dump(payload, f, indent=2, ensure_ascii=False, sort_keys=True)
-
-    print(f"[ok] Report written to {out_file.resolve()}")
-    return payload
-
-# def write_dummy_report(model_path: str, defense: str, out_path: str, version: str = "0.1.0"):
-#     """
-#     Write a placeholder JSON report. Used for Sprint 1 demo.
-
-#     Args:
-#         model_path (str): Path to the model file.
-#         defense (str): The defense name (currently ignored).
-#         out_path (str): Path to write the JSON report.
-#         version (str): Framework version string.
-#     """
-#     payload = {
-#         "mithridatium_version": version,
-#         "timestamp_utc": dt.datetime.utcnow().isoformat() + "Z",
-#         "model_path": str(model_path),
-#         "defense": defense,
-#         "status": "Not yet implemented"
-#     }
-
-#     out_file = Path(out_path)
-#     out_file.parent.mkdir(parents=True, exist_ok=True)
-
-#     with out_file.open("w") as f:
-#         json.dump(payload, f, indent=2)
-
-#     print(f"[ok] Dummy report written to {out_file.resolve()}")
-#     return payload
-
-def build_report(model_path: str, defense: str, dataset: str, version: str = "0.1.0",
-                 results: Dict[str, Any] | None = None) -> Dict[str, Any]:
-    return {
-        "mithridatium_version": version,
-        "model_path": model_path,
-        "defense": defense,
-        "dataset": dataset,
-        "results": results or {
-            "suspected_backdoor": False,
-            "num_flagged": 0,
-            "top_eigenvalue": 0.0,
-        },
-    }
-
 def run_mmbd_stub(model_path: str, dataset: str) -> Dict[str, Any]:
     # placeholder metrics to satisfy acceptance criteria; swap with real MMBD later
     return {"suspected_backdoor": True, "num_flagged": 500, "top_eigenvalue": 42.3}
 
-def render_summary(report: Dict[str, Any]) -> str:
-    r = report["results"]
-    return (
-        f"Mithridatium {report['mithridatium_version']} | "
-        f"defense={report['defense']} | dataset={report['dataset']}\n"
-        f"- model_path:        {report['model_path']}\n"
-        f"- suspected_backdoor:{r.get('suspected_backdoor')}\n"
-        f"- num_flagged:       {r.get('num_flagged')}\n"
-        f"- top_eigenvalue:    {r.get('top_eigenvalue')}"
-    )
 def _json_safe(obj):
     import numpy as np
     if isinstance(obj, dict):
@@ -123,3 +74,17 @@ def _json_safe(obj):
     if isinstance(obj, (np.integer,)):
         return int(obj)
     return obj
+
+def _schema_path() -> Path:
+    return Path(__file__).resolve().parents[1] / "reports" / "report_schema.json"
+
+def validate_report_data(data: dict, schema: str | None = None) -> None:
+    """
+    Validate an in-memory report dict against the JSON Schema.
+    Silent on success. Raises on invalid or if jsonschema is missing.
+    """
+    if jsonschema is None:
+        raise RuntimeError("jsonschema is required. Install with: pip install jsonschema")
+    sch_path = Path(schema) if schema else _schema_path()
+    sch = json.loads(sch_path.read_text(encoding="utf-8"))
+    jsonschema.validate(instance=data, schema=sch)

--- a/reports/report_schema.json
+++ b/reports/report_schema.json
@@ -1,0 +1,21 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"type": "object",
+	"required": [
+		"mithridatium_version",
+		"timestamp_utc",
+		"model_path",
+		"defense",
+		"dataset",
+		"results"
+	],
+	"properties": {
+		"mithridatium_version": { "type": "string" },
+		"timestamp_utc": { "type": "string" },
+		"model_path": { "type": "string" },
+		"defense": { "type": "string" },
+		"dataset": { "type": "string" },
+		"results": { "type": "object" }
+	},
+	"additionalProperties": true
+}


### PR DESCRIPTION
This PR adds a show-report command that validates a saved report against our JSON schema and then displays it. It also adds a formal report schema and a validator in report.py, along with documentation updates so teammates can run and inspect reports.

# 1. What was Changed

- Added mithridatium show-report command:
- Validates a report JSON against reports/report_schema.json.
- On success: prints pretty JSON (default) or a human-summary (--mode summary) if kept.
- On failure: prints a single error and exits non-zero.
- Added JSON Schema at reports/report_schema.json
- Implemented validate_report_data(data) in report.py (quiet on success; raises on invalid/missing jsonschema).
- Updated README:
- Added EXIT_DATA_ERR (65) description for invalid report data.
- Adjusted .gitignore to track only reports/report_schema.json while keeping other reports/ outputs ignored.

# 2. Why it was Changed

- Reports were being generated without a guaranteed, enforced structure. A formal schema plus an easy validation command helps:
- Keep downstream tooling/automation reliable.
- Catch malformed or partially written reports early.
- Provide a simple way for teammates to inspect outputs without external tools.

# 3. How it was Changed

CLI
- Added a new Typer command show-report with options:
- -f/--file: path to the report JSON.
- -m/--mode: json (default) or summary (calls render_summary if present).
- Flow: read file → parse JSON → validate_report_data(data) → render (json/summary).

Validation
- report.py now exports validate_report_data(data). It loads schema from a fixed path: <repo_root>/reports/report_schema.json and validates with jsonschema.validate.