### PR TITLE
Strip metrics issue

### DIFF
--- a/mithridatium/defenses/strip.py
+++ b/mithridatium/defenses/strip.py
@@ -1,5 +1,6 @@
 import torch
 import random
+import numpy as np
 from typing import Dict, Any, List
 
 from mithridatium import utils
@@ -94,9 +95,18 @@ def strip_scores(model, configs, num_bases: int = 32, num_perturbations: int = 1
             # Aggregate entropy for this base sample
             mean_entropy = entropies.mean().item()
             entropies_list.append(mean_entropy)
+    if not entropies_list:
+        raise ValueError("No entropies were computed.")
+    
+    entropy_mean = float(np.mean(entropies_list))
+    entropy_min  = float(np.min(entropies_list))
+    entropy_max  = float(np.max(entropies_list))
 
     return {
         "entropies": entropies_list,
         "num_bases": num_bases,
+        "entropy_mean": entropy_mean,
+        "entropy_min": entropy_min,
+        "entropy_max": entropy_max,
         "num_perturbations": num_perturbations
     }

--- a/mithridatium/report.py
+++ b/mithridatium/report.py
@@ -71,6 +71,18 @@ def render_summary(report: Dict[str, Any]) -> str:
     if ("entropies" in r):
         #STRIP Report
         lines = [head]
+        mean_e = r.get("entropy_mean")
+        min_e  = r.get("entropy_min")
+        max_e  = r.get("entropy_max")
+
+        if isinstance(mean_e, (int, float)):
+            lines.append(f"- entropy_mean:      {mean_e:.6f}\n")
+        if isinstance(min_e, (int, float)):
+            lines.append(f"- entropy_min:       {min_e:.6f}\n")
+        if isinstance(max_e, (int, float)):
+            lines.append(f"- entropy_max:       {max_e:.6f}\n")
+
+
         num_bases = r.get("num_bases")
         if num_bases is not None:
             lines.append(f"- num_bases: {num_bases}\n")


### PR DESCRIPTION
Fixes #46 

This PR extends the STRIP defense output to include basic summary statistics (`entropy_mean`, `entropy_min`, `entropy_max`) to make the results more interpretable without introducing any thresholding or classification. This aligns with the acceptance criteria defined in the issue.

No new dependencies were added.

---

## **1. What Was Changed**

- STRIP now computes and returns three summary statistics over entropy values.  

- The JSON report includes `entropy_mean`, `entropy_min`, and `entropy_max`.  

- The CLI printed summary (via `render_summary`) now displays these values alongside the existing STRIP fields.

---

## **2. Why It Was Changed**

Previously, STRIP only returned raw per-base entropies, which made interpretation difficult without manually inspecting the entire array.  

Adding simple descriptive statistics improves readability and supports easier comparison across runs—without prematurely introducing a threshold or verdict mechanism.

---

## **3. How It Was Changed**

- Added a statistics block at the end of `strip_scores()` to compute mean/min/max once all entropies are collected.  

- Updated the returned results dictionary to include the new fields.  

- Extended `render_summary()` to show these values in the STRIP-specific text summary.  

- Added a small safety check to avoid NumPy reductions on an empty list.

No structural or architectural changes were required.

---

<img width="524" height="621" alt="image" src="https://github.com/user-attachments/assets/02404a2f-3e3c-43a0-baf1-36c12e673be9" />

---
