### PR TITLE
Strip fix. Adding .pth compatibility and updated strip defense

### DIFF
--- a/mithridatium/cli.py
+++ b/mithridatium/cli.py
@@ -166,14 +166,11 @@ def detect(
         )
         raise typer.Exit(code=EXIT_USAGE_ERROR)
     
-        # 4) Build model arch
-    print(f"[cli] building model architecture '{arch}'…")
-    mdl, feature_module = loader.build_model(arch, num_classes=10)
+    # 4) Auto-detect architecture variant from checkpoint and build + load
+    print(f"[cli] detecting architecture and loading model…")
+    mdl, feature_module = loader.detect_and_build(str(p), arch_hint=arch, num_classes=10)
 
-    # 5) Load weights from checkpoint
-    print("[cli] loading weights…")
-    mdl = loader.load_weights(mdl, str(p))
-
+    
     # 6) Validate model BEFORE any defense runs
     # cfg = utils.load_preprocess_config(str(p))  # has input_size etc.
     cfg = utils.get_preprocess_config(data)  # has input_size etc.

--- a/mithridatium/defenses/strip.py
+++ b/mithridatium/defenses/strip.py
@@ -1,7 +1,7 @@
 import torch
 import random
 import numpy as np
-from typing import Dict, Any, List
+from typing import Dict, Any, List, Optional
 from mithridatium import utils
 
 from mithridatium.defenses.mmbd import get_device
@@ -27,7 +27,8 @@ def strip_scores(
         num_bases: int = 32, 
         num_perturbations: int = 16, 
         device=None,
-        entropy_mean_threshold=0.45
+        entropy_mean_threshold=0.45,
+        seed: Optional[int] = None
         ) -> Dict[str, Any]:
     """
     Computes STRIP-style entropy scores.
@@ -42,6 +43,11 @@ def strip_scores(
     Returns:
         A dictionary containing the raw entropy scores.
     """
+    if seed is not None:
+        torch.manual_seed(seed)
+        random.seed(seed)
+        np.random.seed(seed)
+
     if device is None:
         try:
             device = next(model.parameters()).device
@@ -104,20 +110,17 @@ def strip_scores(
             # Aggregate entropy for this base sample
             mean_entropy = entropies.mean().item()
             entropies_list.append(mean_entropy)
+
     if not entropies_list:
         raise ValueError("No entropies were computed.")
     
     entropy_mean = float(np.mean(entropies_list))
     entropy_min  = float(np.min(entropies_list))
     entropy_max  = float(np.max(entropies_list))
+    entropy_std = float(np.std(entropies_list))
 
-    if not entropies_list:
-        raise ValueError("No entropies were computed.")
-
-    entropy_mean = float(np.mean(entropies_list))
-    entropy_min  = float(np.min(entropies_list))
-    entropy_max  = float(np.max(entropies_list))
-
+    # High mean entropy -> model is less robust to perturbation -> likely backdoored
+    # Low mean entropy -> model handles perturbation well -> likely clean
     if entropy_mean > entropy_mean_threshold:
         verdict = "likely backdoored"
     else:
@@ -130,10 +133,14 @@ def strip_scores(
             "entropy_mean": entropy_mean,
             "entropy_min": entropy_min,
             "entropy_max": entropy_max,
+            "entropy_std": entropy_std,
+
         },
         "parameters": {
             "num_bases": num_bases,
             "num_perturbations": num_perturbations,
+            "seed": seed,
+
         },
         "dataset": str(configs.get_dataset()),
         "verdict": verdict,

--- a/mithridatium/loader.py
+++ b/mithridatium/loader.py
@@ -23,10 +23,7 @@ def load_resnet18(model_path: str | None):
 
     # try to load a checkpoint if provided
     if model_path and Path(model_path).exists():
-        ckpt = torch.load(model_path, map_location="cpu")
-        # allow partial load to avoid shape mismatches early on
-        missing, unexpected = model.load_state_dict(ckpt, strict=False)
-        print(f"[loader] loaded ckpt; missing={len(missing)} unexpected={len(unexpected)}")
+        model = load_weights(model, model_path)
     else:
         print(f"[loader] checkpoint not found at '{model_path}'. Using randomly initialized model (ok for pipeline tests).")
 
@@ -49,12 +46,109 @@ def get_feature_module(model):
     arch = model.__class__.__name__
     if arch == 'ResNet':
         return model.avgpool
-    # Example for future extension:
-    # elif arch == 'VGG':
-    #     return model.classifier[0]
     else:
         raise NotImplementedError(f"Feature module not defined for architecture: {arch}")
-    
+
+def _build_resnet18_cifar(num_classes: int = 10):
+    """
+    Build a CIFAR-adapted ResNet-18.
+
+    Many backdoor research pipelines (BackdoorBench, TrojanZoo, etc.) use a
+    modified ResNet-18 for small images (32x32) with:
+        - conv1: 3x3 kernel, stride=1, padding=1  (instead of 7x7, stride=2, padding=3)
+        - No maxpool layer after conv1
+        - avgpool adjusted with AdaptiveAvgPool2d(1) (same as standard)
+
+    This matches the architecture used in most CIFAR-10 backdoor papers.
+    """
+    m = models.resnet18(weights=None)
+    # Replace the ImageNet-style conv1 (7x7) with CIFAR-style (3x3)
+    m.conv1 = nn.Conv2d(3, 64, kernel_size=3, stride=1, padding=1, bias=False)
+    # Remove maxpool — CIFAR images are too small for it
+    m.maxpool = nn.Identity()
+    # Adjust final classifier
+    m.fc = nn.Linear(m.fc.in_features, num_classes)
+    return m
+
+def detect_and_build(ckpt_path: str, arch_hint: str = "resnet18", num_classes: int = 10):
+    """
+    Auto-detect the architecture variant from checkpoint weights and build
+    the matching model.
+
+    This inspects the checkpoint's conv1.weight shape to determine if the
+    model was trained with a standard ImageNet architecture (7x7 kernel) or
+    a CIFAR-adapted architecture (3x3 kernel), then builds and loads the
+    correct variant.
+
+    Args:
+        ckpt_path: Path to the checkpoint file.
+        arch_hint: Base architecture family (e.g. "resnet18"). Used as a
+            fallback when auto-detection can't determine the variant.
+        num_classes: Number of output classes.
+
+    Returns:
+        Tuple of (model, feature_module) with weights loaded.
+    """
+    # Load and unwrap the checkpoint to inspect weight shapes
+    ckpt = torch.load(ckpt_path, map_location="cpu", weights_only=False)
+    sd = _unwrap_state_dict(ckpt)
+
+    # Auto-detect the variant from weight shapes
+    detected_arch = _detect_resnet_variant(sd)
+
+    if detected_arch != arch_hint:
+        print(f"[loader] auto-detected architecture variant: '{detected_arch}' "
+              f"(hint was '{arch_hint}')")
+
+    # Build the correct model
+    model, feature_module = build_model(detected_arch, num_classes)
+
+    # Load weights into the correctly-shaped model
+    missing, unexpected = model.load_state_dict(sd, strict=False)
+
+    total_params = len(list(model.state_dict().keys()))
+    loaded_params = total_params - len(missing)
+
+    if loaded_params == 0:
+        raise RuntimeError(
+            f"No weights were loaded from '{ckpt_path}' even after "
+            f"auto-detecting architecture '{detected_arch}'. "
+            f"The checkpoint may be incompatible."
+        )
+
+    if missing:
+        print(f"[warn] detect_and_build: {len(missing)} missing keys (partial load)")
+    if unexpected:
+        print(f"[warn] detect_and_build: {len(unexpected)} unexpected keys ignored")
+    print(f"[loader] loaded {loaded_params}/{total_params} parameter tensors "
+          f"from '{ckpt_path}' into '{detected_arch}'")
+
+    return model, feature_module
+
+def _detect_resnet_variant(state_dict: dict) -> str:
+    """
+    Inspect checkpoint weights to determine if this is a standard ImageNet
+    ResNet or a CIFAR-adapted variant.
+
+    Returns:
+        "resnet18"       — standard ImageNet variant (conv1 is 7x7)
+        "resnet18_cifar" — CIFAR-adapted variant (conv1 is 3x3)
+    """
+    conv1_key = "conv1.weight"
+    if conv1_key not in state_dict:
+        # Can't determine — fall back to standard
+        return "resnet18"
+
+    shape = state_dict[conv1_key].shape
+    # Standard ImageNet ResNet-18 conv1: (64, 3, 7, 7)
+    # CIFAR-adapted ResNet-18 conv1:     (64, 3, 3, 3)
+    kernel_size = shape[-1]
+
+    if kernel_size == 3:
+        return "resnet18_cifar"
+    else:
+        return "resnet18"
+
 def build_model(arch: str = "resnet18", num_classes: int = 10):
     """
     Build a model with the specified architecture.
@@ -66,9 +160,14 @@ def build_model(arch: str = "resnet18", num_classes: int = 10):
     Returns:
         Tuple of (model, feature_module).
     """
-    if arch.lower() == "resnet18":
+    arch_lower = arch.lower()
+
+
+    if arch_lower == "resnet18":
         from torchvision.models import resnet18
         m = resnet18(weights=None)
+    elif arch_lower == "resnet18_cifar":
+        m = _build_resnet18_cifar(num_classes)
     elif arch == "resnet34":
         from torchvision.models import resnet34
         m = resnet34(weights=None)
@@ -78,22 +177,70 @@ def build_model(arch: str = "resnet18", num_classes: int = 10):
     m.fc = torch.nn.Linear(m.fc.in_features, num_classes)
     return m, get_feature_module(m)
  
+def _unwrap_state_dict(ckpt: dict) -> dict:
+    """
+    Extract the raw state dict from a checkpoint that may be wrapped
+    in a training checkpoint dict.
+
+    Handles formats like:
+        {'model_state_dict': {...}, 'epoch': 50, 'args': ...}
+        {'state_dict': {...}, ...}
+        {'model': {...}, ...}
+        {'net': {...}, ...}
+    Or a raw state dict with layer keys directly.
+    """
+    state_dict_keys = ["model_state_dict", "state_dict", "model", "net"]
+    if isinstance(ckpt, dict):
+        for key in state_dict_keys:
+            if key in ckpt:
+                print(f"[loader] found weights under '{key}' key, unwrapping")
+                return ckpt[key]
+    return ckpt
 
 def load_weights(model, ckpt_path: str):
     """
     Load model weights from a checkpoint file.
-    
+
+    Handles two common checkpoint formats:
+      1. Raw state dict  — keys are layer names directly
+         e.g. {'conv1.weight': ..., 'bn1.weight': ..., 'fc.bias': ...}
+      2. Training checkpoint dict — weights nested under a key like
+         'model_state_dict', 'state_dict', 'model', or 'net'
+         e.g. {'epoch': 50, 'model_state_dict': {...}, 'args': ...}
+
+    Raises:
+        RuntimeError: If no weights were successfully loaded (all keys missing),
+                      or if there are shape mismatches between checkpoint and model.
+
     Args:
         model: PyTorch model instance.
         ckpt_path: Path to checkpoint file.
-        
+
     Returns:
         Model with loaded weights.
     """
-    sd = torch.load(ckpt_path, map_location="cpu")
+    ckpt = torch.load(ckpt_path, map_location="cpu", weights_only=False)
+    sd = _unwrap_state_dict(ckpt)
+
     missing, unexpected = model.load_state_dict(sd, strict=False)
-    if missing or unexpected:
-        print(f"[warn] load_weights: missing={missing}, unexpected={unexpected}")
+
+    # Fail loudly if nothing actually loaded
+    total_params = len(list(model.state_dict().keys()))
+    loaded_params = total_params - len(missing)
+    if loaded_params == 0:
+        raise RuntimeError(
+            f"No weights were loaded from '{ckpt_path}'. "
+            f"All {total_params} expected keys are missing. "
+            f"Unexpected keys in file: {unexpected[:5]}{'...' if len(unexpected) > 5 else ''}. "
+            f"The checkpoint format may be incompatible."
+        )
+
+    if missing:
+        print(f"[warn] load_weights: {len(missing)} missing keys (partial load)")
+    if unexpected:
+        print(f"[warn] load_weights: {len(unexpected)} unexpected keys ignored")
+    print(f"[loader] loaded {loaded_params}/{total_params} parameter tensors from '{ckpt_path}'")
+
     return model
 
 

--- a/mithridatium/report.py
+++ b/mithridatium/report.py
@@ -94,6 +94,7 @@ def render_summary(report: Dict[str, Any]) -> str:
         # Statistics
         stats = r.get("statistics", {})
         lines.append(f"- entropy_mean:      {stats.get('entropy_mean')}\n")
+        lines.append(f"- entropy_std:       {stats.get('entropy_std')}\n")
         lines.append(f"- entropy_min:       {stats.get('entropy_min')}\n")
         lines.append(f"- entropy_max:       {stats.get('entropy_max')}\n")
 

--- a/tests/test_strip_scores.py
+++ b/tests/test_strip_scores.py
@@ -2,61 +2,170 @@ import torch
 import sys
 import os
 from torch.utils.data import DataLoader, TensorDataset
+from unittest.mock import patch
 
 # Add the project root to the path
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../')))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../')))
 
 from mithridatium.defenses.strip import strip_scores
 from mithridatium.utils import get_preprocess_config
 
+
 class MockModel(torch.nn.Module):
+    """A simple model that maps flattened image inputs to 10-class logits."""
     def __init__(self):
         super().__init__()
-        self.linear = torch.nn.Linear(10, 4)  # 10 features, 4 classes
+        self.linear = torch.nn.Linear(3 * 32 * 32, 10)
 
     def forward(self, x):
         if x.dim() > 2:
-            x = x.view(x.size(0), -1)  # Flatten if needed
+            x = x.view(x.size(0), -1)
         return self.linear(x)
 
-def test_strip_scores():
-    print("Testing strip_scores...")
-    
-    # Setup
+
+def _make_fake_loader(num_samples=200):
+    """Create a fake CIFAR-10-shaped dataloader (3x32x32 images)."""
+    data = torch.randn(num_samples, 3, 32, 32)
+    labels = torch.randint(0, 10, (num_samples,))
+    dataset = TensorDataset(data, labels)
+    return DataLoader(dataset, batch_size=64)
+
+
+def test_strip_scores_basic():
+    """Test that strip_scores returns correct structure and types."""
+    print("Testing strip_scores basic structure...")
+
     torch.manual_seed(42)
     model = MockModel()
-    
-    # Get preprocessing configuration for the CIFAR-10 dataset
-    dataset_name = "cifar10"
-    config = get_preprocess_config(dataset_name)
-    
-    # Create dummy data: 100 samples, 10 features each
-    data = torch.randn(100, 10)  # Simulated input data with 10 features
-    labels = torch.randint(0, 4, (100,))  # Random labels (4 classes)
-    
-    dataset = TensorDataset(data, labels)
-    dataloader = DataLoader(dataset, batch_size=10)
-    
-    # Test execution
-    try:
-        # Run strip_scores on the mock model and dummy data
-        results = strip_scores(model, dataloader, num_bases=5, num_perturbations=10, device='cpu', configs=config)
-        
-        # Extract entropies from the results
-        entropies = results.get("entropies")
-        
-        print(f"Entropies: {entropies}")
-        
-        # Assert that entropies are in the expected format
-        assert isinstance(entropies, list), "Entropies should be a list"
-        assert len(entropies) == 5, f"Expected 5 entropies, got {len(entropies)}"
-        assert all(isinstance(e, float) for e in entropies), "All entropies should be floats"
-        
-        print("strip_scores test passed!")
-        
-    except Exception as e:
-        print(f"strip_scores test failed with error: {e}")
-        raise e
+    config = get_preprocess_config("cifar10")
+
+    # Patch dataloader_for to return our fake loader instead of real CIFAR-10
+    fake_loader = _make_fake_loader(num_samples=200)
+    with patch("mithridatium.defenses.strip.utils.dataloader_for") as mock_dl:
+        mock_dl.return_value = (fake_loader, config)
+        results = strip_scores(
+            model,
+            config,
+            num_bases=5,
+            num_perturbations=10,
+            device="cpu",
+            seed=42
+        )
+
+    # Validate structure
+    assert results["defense"] == "strip"
+    assert "entropies" in results
+    assert "statistics" in results
+    assert "parameters" in results
+    assert "verdict" in results
+    assert "thresholds" in results
+
+    # Validate entropies list
+    entropies = results["entropies"]
+    assert isinstance(entropies, list), "Entropies should be a list"
+    assert len(entropies) == 5, f"Expected 5 entropies, got {len(entropies)}"
+    assert all(isinstance(e, float) for e in entropies), "All entropies should be floats"
+    assert all(e >= 0 for e in entropies), "All entropies should be non-negative"
+
+    # Validate statistics
+    stats = results["statistics"]
+    assert "entropy_mean" in stats
+    assert "entropy_min" in stats
+    assert "entropy_max" in stats
+    assert "entropy_std" in stats
+    assert stats["entropy_min"] <= stats["entropy_mean"] <= stats["entropy_max"]
+
+    # Validate parameters reflect what we passed
+    assert results["parameters"]["num_bases"] == 5
+    assert results["parameters"]["num_perturbations"] == 10
+    assert results["parameters"]["seed"] == 42
+
+    # Validate verdict is one of the expected values
+    assert results["verdict"] in ("likely clean", "likely backdoored")
+
+    print(f"  Verdict: {results['verdict']}")
+    print(f"  Entropy mean: {stats['entropy_mean']:.4f}")
+    print(f"  Entropy std:  {stats['entropy_std']:.4f}")
+    print("strip_scores basic test passed!")
+
+
+def test_strip_scores_reproducibility():
+    """Test that running with the same seed gives identical results."""
+    print("Testing strip_scores reproducibility...")
+
+    model = MockModel()
+    config = get_preprocess_config("cifar10")
+    fake_loader = _make_fake_loader(num_samples=200)
+
+    results = []
+    for _ in range(2):
+        # Reset model to same state
+        torch.manual_seed(0)
+        model_copy = MockModel()
+
+        with patch("mithridatium.defenses.strip.utils.dataloader_for") as mock_dl:
+            mock_dl.return_value = (_make_fake_loader(num_samples=200), config)
+            r = strip_scores(
+                model_copy,
+                config,
+                num_bases=5,
+                num_perturbations=10,
+                device="cpu",
+                seed=123
+            )
+        results.append(r)
+
+    assert results[0]["entropies"] == results[1]["entropies"], (
+        f"Results differ across runs:\n"
+        f"  Run 1: {results[0]['entropies']}\n"
+        f"  Run 2: {results[1]['entropies']}"
+    )
+    assert results[0]["statistics"]["entropy_mean"] == results[1]["statistics"]["entropy_mean"]
+
+    print("strip_scores reproducibility test passed!")
+
+
+def test_strip_scores_verdict_threshold():
+    """Test that the verdict correctly depends on the threshold."""
+    print("Testing strip_scores verdict threshold logic...")
+
+    model = MockModel()
+    config = get_preprocess_config("cifar10")
+
+    # Run with a very low threshold (should flag as backdoored since any entropy > 0)
+    with patch("mithridatium.defenses.strip.utils.dataloader_for") as mock_dl:
+        mock_dl.return_value = (_make_fake_loader(num_samples=200), config)
+        results_low = strip_scores(
+            model, config,
+            num_bases=5, num_perturbations=10,
+            device="cpu", seed=42,
+            entropy_mean_threshold=0.0
+        )
+
+    # Run with a very high threshold (should flag as clean)
+    with patch("mithridatium.defenses.strip.utils.dataloader_for") as mock_dl:
+        mock_dl.return_value = (_make_fake_loader(num_samples=200), config)
+        results_high = strip_scores(
+            model, config,
+            num_bases=5, num_perturbations=10,
+            device="cpu", seed=42,
+            entropy_mean_threshold=100.0
+        )
+
+    assert results_low["verdict"] == "likely backdoored", (
+        f"Expected 'likely backdoored' with threshold 0.0, got '{results_low['verdict']}'"
+    )
+    assert results_high["verdict"] == "likely clean", (
+        f"Expected 'likely clean' with threshold 100.0, got '{results_high['verdict']}'"
+    )
+
+    print(f"  Low threshold verdict:  {results_low['verdict']} (threshold=0.0)")
+    print(f"  High threshold verdict: {results_high['verdict']} (threshold=100.0)")
+    print("strip_scores verdict threshold test passed!")
+
 
 if __name__ == "__main__":
-    test_strip_scores()
+    test_strip_scores_basic()
+    test_strip_scores_reproducibility()
+    test_strip_scores_verdict_threshold()
+    print("\nAll strip_scores tests passed!")


### PR DESCRIPTION
Fixes #68  

Issue arose from non compatible model checkpoints. Specifically, checkpoints with .pth because the model weights were wrapped differently than .pt files. So, I implemented a few functions in loader to unwrap the .pth files, and increased the potential file intake to make our defense more robust. Additionally, I added a std as an indicator to STRIP so that we can detect significant variations in entropy score. Essentially telling us if something is unusual about the models predicting.